### PR TITLE
fix: run uv with writable cache dir to avoid permission issues in OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM registry.redhat.io/ubi9/python-311:9.6
 ENV APP_HOME=/opt/app-root/src
 WORKDIR ${APP_HOME}
 
-USER 0
-
 RUN pip install uv
 
 COPY pyproject.toml .
@@ -20,4 +18,4 @@ USER 1001
 
 EXPOSE 8000
 
-CMD ["uv", "run", "server.py"]
+CMD ["uv", "--cache-dir", "/tmp/uv-cache", "run", "server.py"]


### PR DESCRIPTION

Removed use of root user during build and added --cache-dir=/tmp/uv-cache to the uv run command to ensure the cache is stored in a writable location. This prevents permission errors when running under OpenShift's restricted security context.